### PR TITLE
Bugfix save "Create Version" checkbox state

### DIFF
--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -516,7 +516,7 @@ class ShotgunTranscodePreset(
         CollatedShotPreset.__init__(self, self.properties())
 
         # set default values
-        self._properties["create_version"] = True
+        self._properties["create_version"] = properties.get("create_version", True)
 
         # Handle custom properties from the customize_export_ui hook.
         custom_properties = (


### PR DESCRIPTION
Save the state of the "Create Version" checkbox in the export dialog. 🎉 

#### How to test / what to look for?

- Open a Nuke Studio project
- Open the export dialog for a sequence
- Disable the "Create Version" checkbox for one of the frame exports
- Close the export dialog and save the Preset changes
- Open the export dialog again, the state of the "Create Version" checkbox is saved.

#### Notes

@AutomatikVFX/pipeline
