### PR TITLE
Add Cut-In, Cut-Out fields to Version Data & Pass Shot Properties to App for later use

### DIFF
--- a/python/tk_hiero_export/shot_updater.py
+++ b/python/tk_hiero_export/shot_updater.py
@@ -124,6 +124,9 @@ class ShotgunShotUpdater(
         """
         Execution payload.
         """
+        # NOTE: store shot properties for later use during version creation
+        self.app._shot_preset_properties = self._preset.properties()
+        
         # Only process actual shots... so uncollated items and hero collated items
         if self.isCollated() and not self.isHero():
             return False

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -314,7 +314,7 @@ class ShotgunTranscodeExporter(
             task=self,
             item=item,
             data=self.app.preprocess_data,
-            fields=["sg_head_in", "sg_tail_out"],
+            fields=["sg_head_in", "sg_tail_out","sg_cut_in","sg_cut_out"],
             base_class=HieroGetShot,
         )
 
@@ -356,7 +356,7 @@ class ShotgunTranscodeExporter(
                 "code": file_name,
                 "sg_first_frame": head_in,
                 "sg_last_frame": tail_out,
-                "frame_range": "%s-%s" % (head_in, tail_out),
+                "frame_range": "%s-%s" % (head_in, tail_out)
             }
 
             if self._sg_task is not None:


### PR DESCRIPTION
#### Changes
- add additional fields to the data that gets passed to the version updater hook
- store shot_properties in the app to use them later on when updating the version

#### How to test / what to look for?

Check out [this PR](https://github.com/AutomatikVFX/atk-config-default/pull/751).

@KimGoddardJr 
