### PR TITLE
570 investigate the update of the fptr toolkit components

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,12 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+default_language_version:
+    python: python3
+
 # Exclude the UI files, as they are auto-generated.
 exclude: "ui\/.*py$"
+
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -17,7 +21,6 @@ repos:
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
-      language_version: python3
     # Ensures a file name will resolve on all platform
     - id: check-case-conflict
     # Checks files with the execute bit set have shebangs
@@ -35,4 +38,3 @@ repos:
     rev: 25.1.0
     hooks:
     - id: black
-      language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v5.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -31,8 +31,8 @@ repos:
     # Removes trailing whitespaces.
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
-  - repo: https://github.com/ambv/black
-    rev: 22.3.0
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
     hooks:
     - id: black
       language_version: python3

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 This repository is a part of the ShotGrid Pipeline Toolkit.
 
 - For more information about this app and for release notes, *see the wiki section*.
-- For general information and documentation, click here: https://developer.shotgridsoftware.com/d587be80/?title=Integrations+User+Guide
+- For general information and documentation, click here: https://help.autodesk.com/view/SGDEV/ENU/?contextId=SA_INTEGRATIONS_USER_GUIDE
 - For information about ShotGrid in general, click here: https://help.autodesk.com/view/SGSUB/ENU/
 
 ## Using this app in your Setup
 All the apps that are part of our standard app suite are pushed to our App Store.
 This is where you typically go if you want to install an app into a project you are
 working on. For an overview of all the Apps and Engines in the Toolkit App Store,
-click here: https://developer.shotgridsoftware.com/162eaa4b/?title=Pipeline+Integration+Components
+click here: https://help.autodesk.com/view/SGDEV/ENU/?contextId=PC_TOOLKIT_APPS
 
 ## Have a Question?
-Don't hesitate to contact us! You can find us on https://knowledge.autodesk.com/contact-support
+Don't hesitate to contact us at https://knowledge.autodesk.com/contact-support

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)
 
 ## Documentation
-This repository is a part of the ShotGrid Pipeline Toolkit.
+This repository is a part of the Flow Production Tracking Toolkit.
 
 - For more information about this app and for release notes, *see the wiki section*.
 - For general information and documentation, click here: https://help.autodesk.com/view/SGDEV/ENU/?contextId=SA_INTEGRATIONS_USER_GUIDE
-- For information about ShotGrid in general, click here: https://help.autodesk.com/view/SGSUB/ENU/
+- For information about Flow Production Tracking in general, click here: https://help.autodesk.com/view/SGSUB/ENU/
 
 ## Using this app in your Setup
 All the apps that are part of our standard app suite are pushed to our App Store.

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ working on. For an overview of all the Apps and Engines in the Toolkit App Store
 click here: https://help.autodesk.com/view/SGDEV/ENU/?contextId=PC_TOOLKIT_APPS
 
 ## Have a Question?
-Don't hesitate to contact us at https://knowledge.autodesk.com/contact-support
+Don't hesitate to contact us at https://www.autodesk.com/support

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![VFX Platform](https://img.shields.io/badge/vfxplatform-2025%20%7C%202024%20%7C%202023%20%7C%202022-blue.svg)](http://www.vfxplatform.com/)
+[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.10%20%7C%203.9-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Apps/tk-hiero-export?repoName=shotgunsoftware%2Ftk-hiero-export&branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=95&repoName=shotgunsoftware%2Ftk-hiero-export&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Security
+
+At Autodesk, we know that the security of your data is critical to your studio’s
+operation.
+As the industry shifts to the cloud, ShotGrid knows that security and service
+models are more important than ever.
+
+The confidentiality, integrity, and availability of your content is at the top
+of our priority list.
+Not only do we have a team of ShotGrid engineers dedicated to platform security
+and performance, we are also backed by Autodesk’s security team, also invests
+heavily in the security for broad range of industries and customers.
+We constantly reassess, develop, and improve our risk management program because
+we know that the landscape of security is ever-changing.
+
+If you believe you have found a security vulnerability in any ShotGrid-owned
+repository, please report it to us as described below.
+
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them by sending a message to
+[Autodesk Trust Center](https://www.autodesk.com/trust/contact-us).
+
+Please include as much information as you can provide such as locations,
+configurations, reproduction steps, exploit code, impact, etc.
+
+
+## Additional Information
+
+Please check out the [ShotGrid Security White Paper](https://help.autodesk.com/view/SGSUB/ENU/?guid=SG_Administrator_ar_general_security_ar_security_white_paper_html).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,18 +4,18 @@
 
 At Autodesk, we know that the security of your data is critical to your studio’s
 operation.
-As the industry shifts to the cloud, ShotGrid knows that security and service
+As the industry shifts to the cloud, Flow Production Tracking knows that security and service
 models are more important than ever.
 
 The confidentiality, integrity, and availability of your content is at the top
 of our priority list.
-Not only do we have a team of ShotGrid engineers dedicated to platform security
+Not only do we have a team of Flow Production Tracking engineers dedicated to platform security
 and performance, we are also backed by Autodesk’s security team, also invests
 heavily in the security for broad range of industries and customers.
 We constantly reassess, develop, and improve our risk management program because
 we know that the landscape of security is ever-changing.
 
-If you believe you have found a security vulnerability in any ShotGrid-owned
+If you believe you have found a security vulnerability in any Flow Production Tracking-owned
 repository, please report it to us as described below.
 
 
@@ -32,4 +32,4 @@ configurations, reproduction steps, exploit code, impact, etc.
 
 ## Additional Information
 
-Please check out the [ShotGrid Security White Paper](https://help.autodesk.com/view/SGSUB/ENU/?guid=SG_Administrator_ar_general_security_ar_security_white_paper_html).
+Please check out the [Flow Production Tracking Security White Paper](https://help.autodesk.com/view/SGSUB/ENU/?guid=SG_Administrator_ar_general_security_ar_security_white_paper_html).

--- a/app.py
+++ b/app.py
@@ -195,7 +195,7 @@ class HieroExport(Application):
         self._old_AddDefaultPresets_fn(overwrite)
 
         # Add Shotgun template
-        name = "Basic SG Shot"
+        name = "Basic PTR Shot"
         localpresets = [
             preset.name() for preset in hiero.core.taskRegistry.localPresets()
         ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,4 +40,4 @@ variables:
 jobs:
 - template: build-pipeline.yml@templates
   parameters:
-    skip_tests: true
+    has_unit_tests: false

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,18 +1,18 @@
-ShotGrid Hiero Export API reference, |release|
-##############################################
+Flow Production Tracking Hiero Export API reference, |release|
+##############################################################
 
 Overview
 ********
 
-The ``tk-hiero-export`` app adds custom ShotGrid export processors to the Hiero/Nuke Studio export framework.
+The ``tk-hiero-export`` app adds custom Flow Production Tracking export processors to the Hiero/Nuke Studio export framework.
 
-By way of custom export processors, the user can create and update entities in the current Project in ShotGrid.
+By way of custom export processors, the user can create and update entities in the current Project in Flow Production Tracking.
 
 During the export process a number things can happen:
 
 - Status of associated Shot entities can be updated
 - Nuke scripts can be written into the project's filesystem structure for each Shot that's processed
-- Sequence and Shot entity data can be updated in ShotGrid
+- Sequence and Shot entity data can be updated in Flow Production Tracking
 - Cuts can be update to include new CutItems built from the exported sequences
 
 Documentation from The Foundry concerning the Hiero Python API can be found `here. <https://learn.foundry.com/hiero/developers/11.0/HieroPythonDevGuide/api/index.html>`__
@@ -81,8 +81,8 @@ Resolving strings into Shotgun-queried values
     :members:
 
 
-Resolving ShotGrid Toolkit templates into export string representations
------------------------------------------------------------------------
+Resolving Flow Production Tracking templates into export string representations
+---------------------------------------------------------------------------------------
 
 .. autoclass:: HieroTranslateTemplate
     :members:
@@ -95,8 +95,8 @@ Customizing Version entity data
     :members:
 
 
-Uploading Thumbnails to ShotGrid
---------------------------------
+Uploading Thumbnails to Flow Production Tracking
+------------------------------------------------
 
 .. autoclass:: HieroUploadThumbnail
     :members:

--- a/hooks/hiero_get_shot.py
+++ b/hooks/hiero_get_shot.py
@@ -57,7 +57,9 @@ class HieroGetShot(Hook):
                 "project": self.parent.context.project,
             }
             shot = sg.create("Shot", shot_data, return_fields=fields)
-            self.parent.log_info("Created Shot in ShotGrid: %s" % shot_data)
+            self.parent.log_info(
+                "Created Shot in Flow Production Tracking: %s" % shot_data
+            )
         else:
             shot = shots[0]
 
@@ -121,7 +123,8 @@ class HieroGetShot(Hook):
             }
             parent = sg.create(par_entity_type, par_data)
             self.parent.log_info(
-                "Created %s in ShotGrid: %s" % (par_entity_type, par_data)
+                "Created %s in Flow Production Tracking: %s"
+                % (par_entity_type, par_data)
             )
         else:
             parent = parents[0]

--- a/hooks/hiero_translate_template.py
+++ b/hooks/hiero_translate_template.py
@@ -50,7 +50,7 @@ class HieroTranslateTemplate(Hook):
         try:
             task_filter = self.parent.get_setting("default_task_filter", "[]")
             task_filter = ast.literal_eval(task_filter)
-            for (field, op, value) in task_filter:
+            for field, op, value in task_filter:
                 if field == "step.Step.code":
                     mapping["{Step}"] = value
         except ValueError:
@@ -65,11 +65,11 @@ class HieroTranslateTemplate(Hook):
         if output_type == "script":
             template_str = template_str.replace("{name}", "scene")
 
-        for (orig, repl) in mapping.items():
+        for orig, repl in mapping.items():
             template_str = template_str.replace(orig, repl)
 
         # replace {SEQ} style keys with their translated string value
-        for (name, key) in template.keys.items():
+        for name, key in template.keys.items():
             if isinstance(key, tank.templatekey.SequenceKey):
                 # this is a sequence template, for example {SEQ}
                 # replace it with ####

--- a/hooks/hiero_update_cuts.py
+++ b/hooks/hiero_update_cuts.py
@@ -54,7 +54,9 @@ class HieroUpdateCuts(HookBaseClass):
         :rtype: dict or None
         """
         cut_item = self.parent.sgtk.shotgun.create("CutItem", cut_item_data)
-        self.parent.logger.info("Created CutItem in ShotGrid: %s" % cut_item)
+        self.parent.logger.info(
+            "Created CutItem in Flow Production Tracking: %s" % cut_item
+        )
         return cut_item
 
     def get_cut_thumbnail(self, cut, task_item, preset_properties):

--- a/hooks/hiero_upload_thumbnail.py
+++ b/hooks/hiero_upload_thumbnail.py
@@ -73,7 +73,8 @@ class HieroUploadThumbnail(Hook):
             self.parent.shotgun.upload_thumbnail(entity["type"], entity["id"], path)
         except:
             self.parent.log_info(
-                "Thumbnail for %s was not refreshed in ShotGrid." % source
+                "Thumbnail for %s was not refreshed in Flow Production Tracking."
+                % source
             )
 
             tb = traceback.format_exc()

--- a/info.yml
+++ b/info.yml
@@ -4,8 +4,8 @@ configuration:
     default_task_template:
         type: str
         description: The default shot task template to use when the app is
-                     creating new shots in ShotGrid. This setting is presented
-                     in the Custom ShotGrid Export UI and you can change it
+                     creating new shots in Flow Production Tracking. This setting is presented
+                     in the Custom Flow Production Tracking Export UI and you can change it
                      prior to running the export if you want.
         default_value: Basic shot template
 
@@ -60,7 +60,7 @@ configuration:
         type: str
         description: "A filter that will return the task in the Shot that publishes will
                      be registered against.  This value must be a valid filter that can be
-                     passed to the find method of the ShotGrid api, without a condition for
+                     passed to the find method of the Flow Production Tracking api, without a condition for
                      entity (a value linking entity to the Shot will be added at publish
                      time).  If the filter contains a condition in the form
                      ['step.Step.code', 'is', VALUE], then whatver VALUE is will be used
@@ -84,9 +84,9 @@ configuration:
 
     hook_upload_thumbnail:
         type: hook
-        description: "Called when a thumbnail needs to be uploaded to ShotGrid
+        description: "Called when a thumbnail needs to be uploaded to Flow Production Tracking
                      for a Hiero source.  First argument is a dictionary that
-                     is the ShotGrid entity to upload for.  The second argument
+                     is the Flow Production Tracking entity to upload for.  The second argument
                      is the Hiero Source to get the thumbnail from. The third
                      argument is the Hiero TrackItem that the source was pulled
                      from.  The TrackItem may be None when the thumbnail does
@@ -104,7 +104,7 @@ configuration:
 
                      The return value is a data dictionary for the shot, whose
                      id will be updated.  Cut information will be merged into this
-                     dictionary before ShotGrid update is called on the shot.
+                     dictionary before Flow Production Tracking update is called on the shot.
                      The default implementation creates or looks up a sequence
                      named after the Hiero Sequence being exported and links that to
                      the shot via the sg_sequence field."
@@ -113,7 +113,7 @@ configuration:
 
     hook_pre_export:
         type: hook
-        description: "Called prior to starting ShotGrid's shot processor. It can be used
+        description: "Called prior to starting Flow Production Tracking's shot processor. It can be used
                       to clear out caches and do other specific initializations."
         parameters: [processor]
         default_value: hiero_pre_export
@@ -133,7 +133,7 @@ configuration:
         type: hook
         description: "Called when generating the default settings for creating
                      a quicktime.  The argument is a boolean that is True when
-                     the resulting quicktime is only for upload to ShotGrid and
+                     the resulting quicktime is only for upload to Flow Production Tracking and
                      False when the settings are used for a default Quicktime
                      transcode.
 
@@ -147,10 +147,10 @@ configuration:
 
     hook_update_version_data:
         type: hook
-        description: "Called before creating a Version in ShotGrid for a transcode.
+        description: "Called before creating a Version in Flow Production Tracking for a transcode.
                      The default values for the version will already be filled in
                      in the version_data dictionary.  Modify this dictionary to
-                     change what will be passed as an argument to the ShotGrid API
+                     change what will be passed as an argument to the Flow Production Tracking API
                      create call."
         parameters: [version_data, task]
         default_value: hiero_update_version_data
@@ -165,10 +165,10 @@ configuration:
 
     hook_get_extra_publish_data:
         type: hook
-        description: "Called before creating a PublishedFile in ShotGrid for a transcode.
+        description: "Called before creating a PublishedFile in Flow Production Tracking for a transcode.
                      This hook should return None if there is no extra info to
                      associate with the published file, or a dictionary that is
-                     compatible with the ShotGrid API's update method."
+                     compatible with the Flow Production Tracking API's update method."
         parameters: [task]
         default_value: hiero_get_extra_publish_data
 
@@ -183,7 +183,7 @@ configuration:
 
     hook_update_shot:
         type: hook
-        description: "Called during SG shot processing. Provides methods for managing
+        description: "Called during PTR shot processing. Provides methods for managing
                      if and how the Shot's entity in updated, and if and how creation
                      of the Shots filesystem structure happens during export."
         parameters: []
@@ -191,7 +191,7 @@ configuration:
 
     hook_update_cuts:
         type: hook
-        description: "Called during SG shot processing. Provides methods for managing
+        description: "Called during PTR shot processing. Provides methods for managing
                      if and how Cuts and CutItems are created and updated."
         parameters: []
         default_value: hiero_update_cuts
@@ -235,11 +235,11 @@ supported_engines: [tk-hiero, tk-nuke]
 requires_shotgun_fields:
 
 # More verbose description of this item
-display_name: "ShotGrid Export"
-description: "App that adds ShotGrid awareness to Nuke Studio's sequence export.  It
+display_name: "Flow Production Tracking Export"
+description: "App that adds Flow Production Tracking awareness to Nuke Studio's sequence export.  It
              adds a new processor that will use the configuration to determine
              paths for Nuke scripts and plates.  It also will use the tags to
-             determine ShotGrid Shot status and task templates to create/update
-             the Shots in ShotGrid."
+             determine Flow Production Tracking Shot status and task templates to create/update
+             the Shots in Flow Production Tracking."
 
 requires_core_version: "v0.18.124"

--- a/python/base_hooks/hiero_customize_export_ui.py
+++ b/python/base_hooks/hiero_customize_export_ui.py
@@ -71,7 +71,7 @@ class HieroCustomizeExportUI(HookBaseClass):
                     label="Create Cut:",
                     name="custom_create_cut_bool_property",
                     value=True,
-                    tooltip="Create a Cut and CutItems in ShotGrid...",
+                    tooltip="Create a Cut and CutItems in Flow Production Tracking...",
                 ),
                 dict(
                     label="Head In:",

--- a/python/tk_hiero_export/base.py
+++ b/python/tk_hiero_export/base.py
@@ -62,12 +62,12 @@ class ShotgunHieroObjectBase(object):
         # We key off of the method name since we allow for different
         # properties and custom widgets per exporter type.
         if get_method not in self._custom_property_definitions:
-            self._custom_property_definitions[
-                get_method
-            ] = self.app.execute_hook_method(
-                "hook_customize_export_ui",
-                get_method,
-                base_class=HieroCustomizeExportUI,
+            self._custom_property_definitions[get_method] = (
+                self.app.execute_hook_method(
+                    "hook_customize_export_ui",
+                    get_method,
+                    base_class=HieroCustomizeExportUI,
+                )
             )
 
         return self._custom_property_definitions[get_method]

--- a/python/tk_hiero_export/base.py
+++ b/python/tk_hiero_export/base.py
@@ -182,7 +182,7 @@ class ShotgunHieroObjectBase(object):
             self.app.shotgun.upload_thumbnail(sg_entity["type"], sg_entity["id"], path)
         except Exception as e:
             self.app.log_info(
-                "Thumbnail for %s %s (#%s) was not refreshed in ShotGrid: %s"
+                "Thumbnail for %s %s (#%s) was not refreshed in Flow Production Tracking: %s"
                 % (sg_entity["type"], sg_entity.get("name"), sg_entity["id"], e)
             )
         finally:

--- a/python/tk_hiero_export/collating_exporter.py
+++ b/python/tk_hiero_export/collating_exporter.py
@@ -16,8 +16,6 @@ import hiero
 
 class CollatingExporter(object):
     def __init__(self, properties=None):
-        super(CollatingExporter, self).__init__()
-
         # When building a collated sequence, everything is offset by 1000
         # This gives head room for shots which may go negative when transposed to a
         # custom start frame. This offset should be negated during script generation.

--- a/python/tk_hiero_export/collating_exporter_ui.py
+++ b/python/tk_hiero_export/collating_exporter_ui.py
@@ -56,7 +56,7 @@ class CollatingExporterUI(object):
 
         if cut_support:
             cut_lbl = QtGui.QLabel(
-                "NOTE: Cuts in SG are only created when collate is off."
+                "NOTE: Cuts in PTR are only created when collate is off."
             )
             color_role = QtGui.QPalette.WindowText
             palette = widget.palette()

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -62,7 +62,7 @@ class ShotgunAudioExporterUI(ShotgunHieroObjectBase, FnAudioExportUI.AudioExport
 
 
 class ShotgunAudioExporter(
-    ShotgunHieroObjectBase, FnAudioExportTask.AudioExportTask, CollatingExporter
+    ShotgunHieroObjectBase, CollatingExporter, FnAudioExportTask.AudioExportTask
 ):
     """
     Create Audio object and send to Shotgun
@@ -144,7 +144,12 @@ class ShotgunAudioExporter(
         # figure out the thumbnail frame
         ##########################
         source = self._item.source()
-        self._thumbnail = source.thumbnail(source.posterFrame())
+        try:
+            self._thumbnail = source.thumbnail(source.posterFrame())
+        except RuntimeError:
+            # Nuke 16.0 issues a RuntimeError when trying to get the thumbnail
+            # RuntimeError: Layer does not exist
+            self.app.logger.error("Unable to extract thumbnail", exc_info=True)
 
         return FnAudioExportTask.AudioExportTask.startTask(self)
 
@@ -304,7 +309,7 @@ class ShotgunAudioExporter(
 
 
 class ShotgunAudioPreset(
-    ShotgunHieroObjectBase, FnAudioExportTask.AudioExportPreset, CollatedShotPreset
+    ShotgunHieroObjectBase, CollatedShotPreset, FnAudioExportTask.AudioExportPreset
 ):
     """
     Settings for the shotgun audio export step

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -37,7 +37,7 @@ class ShotgunAudioExporterUI(ShotgunHieroObjectBase, FnAudioExportUI.AudioExport
     def __init__(self, preset):
         FnAudioExportUI.AudioExportUI.__init__(self, preset)
 
-        self._displayName = "SG Audio Export"
+        self._displayName = "PTR Audio Export"
         self._taskType = ShotgunAudioExporter
 
     def populateUI(self, widget, exportTemplate):
@@ -294,7 +294,9 @@ class ShotgunAudioExporter(
             args["task"] = self._sg_task
 
         # register publish
-        self.app.log_debug("Register publish in ShotGrid: %s" % str(args))
+        self.app.log_debug(
+            "Register publish in Flow Production Tracking: %s" % str(args)
+        )
         pub_data = sgtk.util.register_publish(**args)
 
         # upload thumbnail for publish

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -158,7 +158,12 @@ class ShotgunNukeShotExporter(
             )
 
         source = self._item.source()
-        self._thumbnail = source.thumbnail(source.posterFrame())
+        try:
+            self._thumbnail = source.thumbnail(source.posterFrame())
+        except RuntimeError:
+            # Nuke 16.0 issues a RuntimeError when trying to get the thumbnail
+            # RuntimeError: Layer does not exist
+            self.app.logger.error("Unable to extract thumbnail", exc_info=True)
 
         return FnNukeShotExporter.NukeShotExporter.taskStep(self)
 
@@ -318,7 +323,7 @@ class ShotgunNukeShotExporter(
 
 
 class ShotgunNukeShotPreset(
-    ShotgunHieroObjectBase, FnNukeShotExporter.NukeShotPreset, CollatedShotPreset
+    ShotgunHieroObjectBase, CollatedShotPreset, FnNukeShotExporter.NukeShotPreset
 ):
     """
     Settings for the shotgun transcode step

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -34,7 +34,7 @@ class ShotgunNukeShotExporterUI(
 
     def __init__(self, preset):
         FnNukeShotExporterUI.NukeShotExporterUI.__init__(self, preset)
-        self._displayName = "SG Nuke Project File"
+        self._displayName = "PTR Nuke Project File"
         self._taskType = ShotgunNukeShotExporter
 
     def populateUI(self, widget, exportTemplate):
@@ -79,11 +79,11 @@ class ShotgunNukeShotExporterUI(
             form_layout = layout
 
         if form_layout:
-            form_layout.insertRow(0, "SG Write Nodes:", self._toolkit_list)
+            form_layout.insertRow(0, "PTR Write Nodes:", self._toolkit_list)
         else:
             self.app.log_error(
                 "Unable to find the expected UI layout to display the list of "
-                "SG Write Nodes in the export dialog."
+                "PTR Write Nodes in the export dialog."
             )
 
         # Handle any custom widget work the user did via the custom_export_ui
@@ -212,11 +212,13 @@ class ShotgunNukeShotExporter(
 
         publish_entity_type = sgtk.util.get_published_file_entity_type(self.app.sgtk)
 
-        self.app.log_debug("Register publish in ShotGrid: %s" % str(args))
+        self.app.log_debug(
+            "Register publish in Flow Production Tracking: %s" % str(args)
+        )
         sg_publish = sgtk.util.register_publish(**args)
         if self._extra_publish_data is not None:
             self.app.log_debug(
-                "Updating SG %s %s"
+                "Updating PTR %s %s"
                 % (publish_entity_type, str(self._extra_publish_data))
             )
             self.app.shotgun.update(
@@ -231,7 +233,7 @@ class ShotgunNukeShotExporter(
         )
         if extra_publish_data is not None:
             self.app.log_debug(
-                "Updating SG %s %s" % (publish_entity_type, str(extra_publish_data))
+                "Updating PTR %s %s" % (publish_entity_type, str(extra_publish_data))
             )
             self.app.shotgun.update(
                 sg_publish["type"], sg_publish["id"], extra_publish_data
@@ -252,8 +254,8 @@ class ShotgunNukeShotExporter(
         This method overrides the default method added to the base class in
         Nuke 10. The base class returns ``True`` for all items found in the
         list of collated items. This prevents unnecessary exports for those items
-        since non-SG workflows only collate into the exported nuke script of the
-        first exported track item. For SG workflows, we still export versions
+        since non-PTR workflows only collate into the exported nuke script of the
+        first exported track item. For PTR workflows, we still export versions
         for collated tracks and link them back to the hero shot. So we need to
         do our own culling of tasks in the shot processor. So we return ``False``
         unless the item is the current item.
@@ -306,7 +308,7 @@ class ShotgunNukeShotExporter(
                 # now add our new node to the layout
                 currentLayoutContext.getNodes().append(node)
         except Exception:
-            self.app.logger.exception("Failed to add SG writenodes")
+            self.app.logger.exception("Failed to add PTR writenodes")
         finally:
             # now put back the viewer nodes layout
             currentLayoutContext.getNodes().append(oldLayoutEnd)

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -198,7 +198,7 @@ class ShotgunShotProcessorUI(
             properties["sg_cut_type"] = new_value
 
         # connect the widget index changed to the callback
-        cut_type_widget.currentIndexChanged[str].connect(value_changed)
+        cut_type_widget.currentTextChanged.connect(value_changed)
 
         # ---- construct the layout with a label
 
@@ -250,7 +250,7 @@ class ShotgunShotProcessorUI(
         tagTable.setMinimumHeight(150)
         tagTable.setHorizontalHeaderLabels(["Hiero Tags"] + labels)
         tagTable.setAlternatingRowColors(True)
-        tagTable.setSelectionMode(tagTable.NoSelection)
+        tagTable.setSelectionMode(QtGui.QAbstractItemView.SelectionMode.NoSelection)
         tagTable.setShowGrid(False)
         tagTable.verticalHeader().hide()
         tagTable.horizontalHeader().setStretchLastSection(True)
@@ -298,7 +298,9 @@ class ShotgunShotProcessorUI(
                 # adjust sizes to avoid clipping or scrolling
                 width = combo.minimumSizeHint().width()
                 combo.setMinimumWidth(width)
-                combo.setSizeAdjustPolicy(combo.AdjustToContents)
+                combo.setSizeAdjustPolicy(
+                    QtGui.QComboBox.SizeAdjustPolicy.AdjustToContents
+                )
                 tagTable.setCellWidget(row, col + 1, combo)
 
         tagTable.resizeRowsToContents()
@@ -834,7 +836,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
 
 
 class ShotgunShotProcessorPreset(
-    ShotgunHieroObjectBase, FnShotProcessor.ShotProcessorPreset, CollatedShotPreset
+    ShotgunHieroObjectBase, CollatedShotPreset, FnShotProcessor.ShotProcessorPreset
 ):
     """
     Handles presets for the shot processor.

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -61,10 +61,10 @@ class ShotgunShotProcessorUI(
         CollatingExporterUI.__init__(self)
 
     def displayName(self):
-        return "Process as SG Shots"
+        return "Process as PTR Shots"
 
     def toolTip(self):
-        return "Process as SG Shots generates output on a per-shot basis and logs it in SG."
+        return "Process as PTR Shots generates output on a per-shot basis and logs it in PTR."
 
     def populateUI(self, *args, **kwargs):
         """
@@ -84,7 +84,7 @@ class ShotgunShotProcessorUI(
         master_layout.setContentsMargins(0, 0, 0, 0)
 
         # add group box for shotgun stuff
-        shotgun_groupbox = QtGui.QGroupBox("SG Shot and Sequence Creation Settings")
+        shotgun_groupbox = QtGui.QGroupBox("PTR Shot and Sequence Creation Settings")
         master_layout.addWidget(shotgun_groupbox)
         shotgun_layout = QtGui.QVBoxLayout(shotgun_groupbox)
 
@@ -93,12 +93,12 @@ class ShotgunShotProcessorUI(
         header_text.setWordWrap(True)
         header_text.setText(
             """
-            <big>Welcome to the ShotGrid Shot Exporter!</big>
-            <p>When you are using the ShotGrid Shot Processor, Shots and
-            Sequences in ShotGrid will be created based on the curent timeline.
+            <big>Welcome to the Flow Production Tracking Shot Exporter!</big>
+            <p>When you are using the Flow Production Tracking Shot Processor, Shots and
+            Sequences in Flow Production Tracking will be created based on the curent timeline.
             Existing Shots will be updated with the latest cut lengths.
             Quicktimes for each shot will be reviewable in the Media app when
-            you use the special ShotGrid Transcode plugin - all included and
+            you use the special Flow Production Tracking Transcode plugin - all included and
             ready to go in the default preset.
             </p>
             """
@@ -167,7 +167,7 @@ class ShotgunShotProcessorUI(
         :param properties: A dict containing the 'sg_cut_type' preset
         :return: QtGui.QLayout - for the cut type widget
         """
-        tooltip = "What to populate in the `Type` field for this Cut in ShotGrid"
+        tooltip = "What to populate in the `Type` field for this Cut in Flow Production Tracking"
 
         # ---- construct the widget
 
@@ -227,7 +227,7 @@ class ShotgunShotProcessorUI(
         statuses = schema["sg_status_list"]["properties"]["valid_values"]["value"]
 
         values = [statuses, templates]
-        labels = ["SG Shot Status", "SG Task Template for Shots"]
+        labels = ["PTR Shot Status", "PTR Task Template for Shots"]
         keys = ["sg_status_hiero_tags", "task_template_map"]
 
         # build a map of tag value pairs from the properties
@@ -496,7 +496,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         if not self._cutsSupported():
             # cuts not supported. all done here
             self.app.log_info(
-                "No Cut support in this version of ShotGrid. Not attempting to "
+                "No Cut support in this version of Flow Production Tracking. Not attempting to "
                 "create Cut or CutItem entries."
             )
             return
@@ -526,13 +526,13 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         if collateTracks or collateShotNames:
             self.app.log_info(
                 "Cut support is ill defined for collating in Hiero. Not "
-                "attempting to create Cut or CutItem entries in ShotGrid."
+                "attempting to create Cut or CutItem entries in Flow Production Tracking."
             )
             return
 
         # ---- at this point, we have the cut related tasks in order.
 
-        self.app.engine.show_busy("Preprocessing Sequence", "Creating Cut in SG ...")
+        self.app.engine.show_busy("Preprocessing Sequence", "Creating Cut in PTR ...")
 
         # wrap in a try/catch to make sure we can clear the popup at the end
         try:
@@ -564,7 +564,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         parent_entity = None
 
         try:
-            # get the parent entity in SG that corresponds to the hiero sequence
+            # get the parent entity in PTR that corresponds to the hiero sequence
             parent_entity = self.app.execute_hook_method(
                 "hook_get_shot",
                 "get_shot_parent",
@@ -581,7 +581,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
             self.app.log_warning(
                 "The method 'get_shot_parent' could not be found in the "
                 "'hook_get_shot' hook. In order to properly link the "
-                "Cut entity in SG, you will need to implement this method "
+                "Cut entity in PTR, you will need to implement this method "
                 "to return a Sequence, Episode, or some other entity "
                 "that corresponds to the Hiero sequence in your workflow."
             )
@@ -636,7 +636,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         used for frame exports called FrameServerRenderTask. This task type
         renders frames in an individual frame context within Nuke and therefore
         our quicktime write node never runs. Thus no quicktime upload for the
-        SG Version and no thumbnail.
+        PTR Version and no thumbnail.
 
         By overriding this method and forcing a value of ``False``, we trick
         the Hiero shot processor internals into thinking that there is no frame
@@ -664,7 +664,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
             # log a debug message in case something happens.
             self._app.log_debug(
                 "Unable to override the frame server check. If exporting individual "
-                "frames, this may prevent the upload of a quicktime to SG."
+                "frames, this may prevent the upload of a quicktime to PTR."
             )
 
     def _restore_frame_server_check(self):
@@ -697,7 +697,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         """
 
         # make sure the data cache is ready. this code may create entities in
-        # SG and they'll be stored here for reuse.
+        # PTR and they'll be stored here for reuse.
         if not hasattr(self.app, "preprocess_data"):
             self.app.preprocess_data = {}
 
@@ -784,7 +784,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
             # dont' want to assume that there is an associated transcode task.
             # if there is, attach the cut item data so that the version is
             # updated. If not, then we'll get a cut item without an associated
-            # version (cut info only in SG, nothing playable).
+            # version (cut info only in PTR, nothing playable).
             if transcode_task:
                 transcode_task._cut_item_data = cut_item_data
 
@@ -808,8 +808,10 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         # create the cut to get the id.
         sg = self.app.shotgun
         cut = sg.create("Cut", cut_data)
-        self._app.log_debug("Created Cut in ShotGrid: %s" % (cut,))
-        self._app.log_info("Created Cut '%s' in ShotGrid!" % (cut["code"],))
+        self._app.log_debug("Created Cut in Flow Production Tracking: %s" % (cut,))
+        self._app.log_info(
+            "Created Cut '%s' in Flow Production Tracking!" % (cut["code"],)
+        )
 
         # make sure the cut item data dicts are updated with the cut info
         for cut_item_data in cut_item_data_list:
@@ -870,7 +872,7 @@ class ShotgunShotProcessorPreset(
             ("Final", default_template),
         ]
 
-        # holds the cut type to use when creating Cut entires in SG
+        # holds the cut type to use when creating Cut entires in PTR
         default_properties["sg_cut_type"] = ""
 
         # Handle custom properties from the customize_export_ui hook.
@@ -897,7 +899,7 @@ class ShotgunShotProcessorPreset(
 
         resolver.addResolver(
             "{tk_version}",
-            "Version string formatted by SG Toolkit.",
+            "Version string formatted by Flow Production Tracking.",
             lambda keyword, task: self._formatTkVersionString(task.versionString()),
         )
 

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -258,8 +258,8 @@ class ShotgunShotProcessorUI(
 
         # on change rebuild the properties
         def changed(index):
-            for (row, name) in enumerate(names):
-                for (col, key) in enumerate(keys):
+            for row, name in enumerate(names):
+                for col, key in enumerate(keys):
                     combo = tagTable.cellWidget(row, col + 1)
 
                     # if no tag mapped to a name
@@ -275,7 +275,7 @@ class ShotgunShotProcessorUI(
 
         # and build the table
         tagsByName = self._get_all_tags_by_name()
-        for (row, name) in enumerate(names):
+        for row, name in enumerate(names):
             tag = tagsByName.get(name, None)
             if tag is None:
                 continue
@@ -286,10 +286,10 @@ class ShotgunShotProcessorUI(
             tagTable.setItem(row, 0, item)
 
             # build combo boxes for each set of values
-            for (col, vals) in enumerate(values):
+            for col, vals in enumerate(values):
                 combo = QtGui.QComboBox()
                 combo.addItem(None)
-                for (i, value) in enumerate(vals):
+                for i, value in enumerate(vals):
                     combo.addItem(value)
                     # see if the current item is the one in the properties
                     if map[name][col] == value:
@@ -367,7 +367,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
 
         # inject collate settings into Tasks where needed
         (collateTracks, collateShotNames) = self._getCollateProperties()
-        for (itemPath, itemPreset) in exportTemplate:
+        for itemPath, itemPreset in exportTemplate:
             if "collateTracks" in itemPreset.properties():
                 itemPreset.properties()["collateTracks"] = collateTracks
             if "collateShotNames" in itemPreset.properties():
@@ -722,7 +722,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         cut_item_data_list = []
 
         # process the tasks in order
-        for (shot_updater_task, transcode_task) in cut_related_tasks:
+        for shot_updater_task, transcode_task in cut_related_tasks:
 
             # cut order was populated by the calling method to update the
             # Shot entity's cut info

--- a/python/tk_hiero_export/shot_updater.py
+++ b/python/tk_hiero_export/shot_updater.py
@@ -95,7 +95,7 @@ class ShotgunShotUpdater(
 
         if cut_duration != edit_duration:
             self.app.log_warning(
-                "It looks like the shot %s has a retime applied. SG cuts do "
+                "It looks like the shot %s has a retime applied. PTR cuts do "
                 "not support retimes." % (self.clipName(),)
             )
 

--- a/python/tk_hiero_export/shot_updater.py
+++ b/python/tk_hiero_export/shot_updater.py
@@ -22,7 +22,7 @@ from . import (
 
 
 class ShotgunShotUpdater(
-    ShotgunHieroObjectBase, FnShotExporter.ShotTask, CollatingExporter
+    ShotgunHieroObjectBase, CollatingExporter, FnShotExporter.ShotTask
 ):
     """
     Ensures that Shots and Sequences exist in Shotgun
@@ -119,6 +119,10 @@ class ShotgunShotUpdater(
             "tail_out": tail_out,
             "working_duration": working_duration,
         }
+
+    def finishTask(self):
+        FnShotExporter.ShotTask.finishTask(self)
+        CollatingExporter.finishTask(self)
 
     def taskStep(self):
         """

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -51,7 +51,7 @@ class ShotgunTranscodeExporterUI(
 
     def __init__(self, preset):
         FnTranscodeExporterUI.TranscodeExporterUI.__init__(self, preset)
-        self._displayName = "SG Transcode Images"
+        self._displayName = "PTR Transcode Images"
         self._taskType = ShotgunTranscodeExporter
 
     def create_version_changed(self, state):
@@ -74,12 +74,12 @@ class ShotgunTranscodeExporterUI(
 
         top_layout = QtGui.QVBoxLayout()
         top_layout.setContentsMargins(9, 0, 9, 0)
-        create_version_checkbox = QtGui.QCheckBox("Create SG Version", widget)
+        create_version_checkbox = QtGui.QCheckBox("Create PTR Version", widget)
         create_version_checkbox.setToolTip(
-            "Create a Version in SG for this transcode.\n\n"
+            "Create a Version in PTR for this transcode.\n\n"
             "If the output format is not a quicktime, then\n"
             "a quicktime will be created.  The quicktime will\n"
-            "be uploaded to SG as Screening Room media."
+            "be uploaded to PTR as Screening Room media."
         )
 
         create_version_checkbox.setCheckState(QtCore.Qt.Checked)
@@ -189,7 +189,7 @@ class ShotgunTranscodeExporter(
 
         self._quicktime_path = os.path.join(tempfile.mkdtemp(), "preview.mov")
         self._temp_quicktime = True
-        nodeName = "SG Screening Room Media"
+        nodeName = "PTR Screening Room Media"
 
         framerate = None
         if self._sequence:
@@ -425,7 +425,7 @@ class ShotgunTranscodeExporter(
         pub_data = tank.util.register_publish(**args)
         if self._extra_publish_data is not None:
             self.app.log_debug(
-                "Updating SG %s %s"
+                "Updating PTR %s %s"
                 % (published_file_entity_type, str(self._extra_publish_data))
             )
             self.app.shotgun.update(
@@ -450,12 +450,13 @@ class ShotgunTranscodeExporter(
             else:  # == "TankPublishedFile
                 self._version_data["tank_published_file"] = pub_data
 
-            self.app.log_debug("Creating SG Version %s" % str(self._version_data))
+            self.app.log_debug("Creating PTR Version %s" % str(self._version_data))
             vers = self.app.shotgun.create("Version", self._version_data)
 
             if os.path.exists(self._quicktime_path):
                 self.app.log_debug(
-                    "Uploading quicktime to ShotGrid... (%s)" % self._quicktime_path
+                    "Uploading quicktime to Flow Production Tracking... (%s)"
+                    % self._quicktime_path
                 )
                 self.app.shotgun.upload(
                     "Version", vers["id"], self._quicktime_path, "sg_uploaded_movie"
@@ -504,7 +505,7 @@ class ShotgunTranscodeExporter(
 class ShotgunTranscodePreset(
     ShotgunHieroObjectBase, FnTranscodeExporter.TranscodePreset, CollatedShotPreset
 ):
-    """Settings for the SG transcode step"""
+    """Settings for the PTR transcode step"""
 
     def __init__(self, name, properties):
         FnTranscodeExporter.TranscodePreset.__init__(self, name, properties)

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -119,7 +119,7 @@ class ShotgunTranscodeExporterUI(
 
 
 class ShotgunTranscodeExporter(
-    ShotgunHieroObjectBase, FnTranscodeExporter.TranscodeExporter, CollatingExporter
+    ShotgunHieroObjectBase, CollatingExporter, FnTranscodeExporter.TranscodeExporter
 ):
     """
     Create Transcode object and send to Shotgun
@@ -503,7 +503,7 @@ class ShotgunTranscodeExporter(
 
 
 class ShotgunTranscodePreset(
-    ShotgunHieroObjectBase, FnTranscodeExporter.TranscodePreset, CollatedShotPreset
+    ShotgunHieroObjectBase, CollatedShotPreset, FnTranscodeExporter.TranscodePreset
 ):
     """Settings for the PTR transcode step"""
 

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -219,7 +219,7 @@ class ShotgunTranscodeExporter(
         # their Python classes out from under us, so now we're going
         # to have to handle this the ugly way, via introspecting the
         # arguments expected by the createWriteNode method.
-        arg_spec = inspect.getargspec(FnExternalRender.createWriteNode)
+        arg_spec = inspect.getfullargspec(FnExternalRender.createWriteNode)
         if "projectsettings" in arg_spec.args:
             kwargs = dict(
                 path=self._quicktime_path,


### PR DESCRIPTION
This pull request updates the project to rebrand from ShotGrid/Shotgun to Flow Production Tracking (PTR) and modernizes tooling and documentation references. The changes include updating terminology throughout code, documentation, and configuration files, as well as upgrading pre-commit hooks and Python version references.

**Rebranding and Terminology Updates:**

* Replaces all references to "ShotGrid" or "Shotgun" with "Flow Production Tracking" or "PTR" in user-facing strings, documentation, configuration descriptions, and log messages across the codebase, including `README.md`, `docs/index.rst`, `info.yml`, and code in `hooks/` and `app.py`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R21) [[2]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L1-R15) [[3]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L84-R85) [[4]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L98-R99) [[5]](diffhunk://#diff-9eece03678e2c9e98f7053139736e003cf4623dcc006fcd7fb4d220ce8d91a00L7-R8) [[6]](diffhunk://#diff-9eece03678e2c9e98f7053139736e003cf4623dcc006fcd7fb4d220ce8d91a00L63-R63) [[7]](diffhunk://#diff-9eece03678e2c9e98f7053139736e003cf4623dcc006fcd7fb4d220ce8d91a00L87-R89) [[8]](diffhunk://#diff-9eece03678e2c9e98f7053139736e003cf4623dcc006fcd7fb4d220ce8d91a00L107-R107) [[9]](diffhunk://#diff-9eece03678e2c9e98f7053139736e003cf4623dcc006fcd7fb4d220ce8d91a00L116-R116) [[10]](diffhunk://#diff-9eece03678e2c9e98f7053139736e003cf4623dcc006fcd7fb4d220ce8d91a00L136-R136) [[11]](diffhunk://#diff-9eece03678e2c9e98f7053139736e003cf4623dcc006fcd7fb4d220ce8d91a00L150-R153) [[12]](diffhunk://#diff-9eece03678e2c9e98f7053139736e003cf4623dcc006fcd7fb4d220ce8d91a00L168-R171) [[13]](diffhunk://#diff-9eece03678e2c9e98f7053139736e003cf4623dcc006fcd7fb4d220ce8d91a00L186-R194) [[14]](diffhunk://#diff-9eece03678e2c9e98f7053139736e003cf4623dcc006fcd7fb4d220ce8d91a00L238-R243) [[15]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L198-R198) [[16]](diffhunk://#diff-9e1034c19d8f75cb39b5c30b6937469a6e9c228d86f6d9b667e26d3f7d3486c9L60-R62) [[17]](diffhunk://#diff-9e1034c19d8f75cb39b5c30b6937469a6e9c228d86f6d9b667e26d3f7d3486c9L124-R127) [[18]](diffhunk://#diff-026e6c817b09b82c05a906be24be954bcf33e57ee372de93d57968a327ec5095L57-R59) [[19]](diffhunk://#diff-54861c0345896c47091972809684089e596a0a018b48e3da60e7d7c9de21cde5L76-R77)

* Updates documentation and support links to point to Autodesk's Flow Production Tracking and support resources, replacing deprecated ShotGrid URLs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R21) [[2]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7R1-R35) [[3]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L1-R15)

**Tooling and Configuration Modernization:**

* Upgrades pre-commit hooks: bumps `pre-commit-hooks` to v5.0.0, switches `black` to the official PSF repo at v25.1.0, and sets the default Python version to Python 3. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R11-L20) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L34-L38)

* Updates Python version badges and VFX Platform references in `README.md` to reflect current supported versions (3.9, 3.10, 3.11).

* Adjusts Azure Pipelines configuration to use `has_unit_tests: false` instead of `skip_tests: true`.

**Minor Code Cleanups:**

* Simplifies tuple unpacking in `hooks/hiero_translate_template.py` for improved readability. [[1]](diffhunk://#diff-afb8e0d7d5dcb3a68ffd6e33a68db593d874fd02d43dbbcd929f3a4e9ac869c3L53-R53) [[2]](diffhunk://#diff-afb8e0d7d5dcb3a68ffd6e33a68db593d874fd02d43dbbcd929f3a4e9ac869c3L68-R72)

**Security Policy Addition:**

* Adds a `SECURITY.md` file with Autodesk security policy and vulnerability reporting instructions.
#### Changes

-

#### How to test / what to look for?

1. Adjust your `atk_default_config` in your dev area to set tk-hiero-export to point to your dev area
2. Load up Nuke studio
3. Load up a Nuke studio tracked file
4. Select Export on a shot/sequence
5. See updated details like changes from Shotgrid to PTR

#### Notes

- [ ] Is documentation up-to-date? (Paste link to documentation page here)

@AutomatikVFX/pipeline
