### PR TITLE
Add compatibility for Nuke Studio/Hiero v17+ while preserving legacy …

### DIFF
--- a/python/tk_hiero_export/collating_exporter.py
+++ b/python/tk_hiero_export/collating_exporter.py
@@ -69,12 +69,17 @@ class CollatingExporter(object):
                     # Find all the effects which apply to collated items
                     from hiero.exporters import FnEffectHelpers
 
-                    (
-                        self._effects,
-                        self._annotations,
-                    ) = FnEffectHelpers.findEffectsAnnotationsForTrackItems(
-                        self._collatedItems
-                    )
+                    if self._is_hiero_v17_or_later():
+                        self._effects = FnEffectHelpers.findEffectsForTrackItems(
+                            self._collatedItems
+                        )
+                    else:
+                        (
+                            self._effects,
+                            self._annotations,
+                        ) = FnEffectHelpers.findEffectsAnnotationsForTrackItems(
+                            self._collatedItems
+                        )
 
                 # Build the sequence of collated shots
                 self._buildCollatedSequence(properties)
@@ -83,12 +88,17 @@ class CollatingExporter(object):
                     # Find the effects which apply to this item.  Note this function expects a list.
                     from hiero.exporters import FnEffectHelpers
 
-                    (
-                        self._effects,
-                        self._annotations,
-                    ) = FnEffectHelpers.findEffectsAnnotationsForTrackItems(
-                        [self._item]
-                    )
+                    if self._is_hiero_v17_or_later():
+                        self._effects = FnEffectHelpers.findEffectsForTrackItems(
+                            [self._item]
+                        )
+                    else:
+                        (
+                            self._effects,
+                            self._annotations,
+                        ) = FnEffectHelpers.findEffectsAnnotationsForTrackItems(
+                            [self._item]
+                        )
 
     def _offsetTimelineLinked(self, trackItem, offset):
         """
@@ -602,9 +612,13 @@ class CollatingExporter(object):
 
         # Copy any effects and add them to the sequence.  We don't do anything with handles here,
         # the effects just have the same timeline duration as before.
-        for subTrackItem in itertools.chain(
-            self._effects, linkedEffects, self._annotations
-        ):
+        if self._is_hiero_v17_or_later():
+            effectsChain = itertools.chain(self._effects, linkedEffects)
+        else:
+            effectsChain = itertools.chain(
+                self._effects, linkedEffects, self._annotations
+            )
+        for subTrackItem in effectsChain:
             parentTrack = subTrackItem.parentTrack()
             newTrack = newTracks[parentTrack.guid()]
             unusedNewTracks.discard(newTrack)
@@ -763,6 +777,21 @@ class CollatingExporter(object):
                 self._has_nuke = True
 
         return self._has_nuke
+
+    def _is_hiero_v17_or_later(self):
+        """
+        Return ``True`` if the current Hiero/Nuke Studio version is 17 or later.
+
+        Hiero v17+ uses ``FnEffectHelpers.findEffectsForTrackItems`` and no
+        longer returns annotations separately, whereas earlier versions use
+        ``FnEffectHelpers.findEffectsAnnotationsForTrackItems``.
+        """
+        if not hasattr(self, "_hiero_v17"):
+            try:
+                self._hiero_v17 = int(hiero.core.env.get("VersionMajor", 0)) >= 17
+            except Exception:
+                self._hiero_v17 = False
+        return self._hiero_v17
 
 
 def _clone_item(item):


### PR DESCRIPTION
This pull request updates the `collating_exporter.py` module to support compatibility with Hiero/Nuke Studio version 17 and later. The main changes involve adapting the way effects and annotations are handled, ensuring the exporter works correctly with both newer and older versions of Hiero.

**Hiero v17+ compatibility:**

* Added a new helper method `_is_hiero_v17_or_later` to detect if the running Hiero/Nuke Studio version is 17 or later.
* Updated logic for finding effects on collated items and individual items to use `FnEffectHelpers.findEffectsForTrackItems` for Hiero v17+, while retaining the old method for earlier versions. [[1]](diffhunk://#diff-4455638d7224a08cdcfba123b708c03d10b08d16f63d00b291664f67e5f6a0d2R72-R76) [[2]](diffhunk://#diff-4455638d7224a08cdcfba123b708c03d10b08d16f63d00b291664f67e5f6a0d2R91-R95)
* Modified the logic for copying effects to sequences so that annotations are only included for pre-v17 versions, reflecting the change in how effects and annotations are returned in v17+.…support

#### How to test / what to look for?
You'll also need this PR branch to get the templates in v16 an v17 - https://github.com/AutomatikVFX/nuke/issues/408
Remember you will have to set tk-heiro-exporter in your config area to pull from your local area rather than git
1. Load up the exporter on a scene in Nuke Studio v17 and try export. It should work
2. Load up the exporter on a scene in Nuke Studio v16 and below and try export. It should work

#### Notes

~- [ ] Is documentation up-to-date? (Paste link to documentation page here)~

@AutomatikVFX/pipeline
